### PR TITLE
fix: excluded node_modules and __lwr_cache__ from search list

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -5,12 +5,14 @@ return {
         dependencies = { 'nvim-lua/plenary.nvim' },
         config = function()
             local builtin = require 'telescope.builtin'
+
             vim.keymap.set(
                 'n',
                 '<leader>tf',
                 builtin.find_files,
                 { desc = 'Search for the files in current directory' }
             )
+
             vim.keymap.set('n', '<leader>tg', builtin.live_grep, { desc = 'Grep in current directory' })
         end,
     },
@@ -18,12 +20,19 @@ return {
         'nvim-telescope/telescope-ui-select.nvim',
         config = function()
             require('telescope').setup {
+                defaults = {
+                    file_ignore_patterns = {
+                        'node_modules',
+                        '__lwr_cache__',
+                    },
+                },
                 extensions = {
                     ['ui-select'] = {
                         require('telescope.themes').get_dropdown {},
                     },
                 },
             }
+
             require('telescope').load_extension 'ui-select'
         end,
     },


### PR DESCRIPTION
Excluded patterns from search-list:
- node_modules
- \_\_lwr_cache\_\_